### PR TITLE
Added files to create Docker image of Chrome, puppeteer and jest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Screenshots
 *.png
+screenshots/*
 
 # Dependency directories
 node_modules/

--- a/puppeteer-and-jest-google/.dockerignore
+++ b/puppeteer-and-jest-google/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.DS_Store

--- a/puppeteer-and-jest-google/Dockerfile
+++ b/puppeteer-and-jest-google/Dockerfile
@@ -1,0 +1,51 @@
+FROM node:8-slim as puppeteer
+
+# See https://crbug.com/795759
+RUN apt-get update && apt-get install -yq libgconf-2-4
+
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+# installs, work.
+RUN apt-get update && apt-get install -y wget --no-install-recommends \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get purge --auto-remove -y curl \
+    && rm -rf /src/*.deb
+
+# It's a good idea to use dumb-init to help prevent zombie chrome processes.
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+
+# Uncomment to skip the chromium download when installing puppeteer. If you do,
+# you'll need to launch puppeteer with:
+#     browser.launch({executablePath: 'google-chrome-unstable'})
+# ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
+# Install puppeteer so it's available in the container.
+RUN npm i puppeteer
+
+# Add user so we don't need --no-sandbox.
+RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
+    && mkdir -p /home/pptruser/Downloads \
+    && chown -R pptruser:pptruser /home/pptruser \
+    && chown -R pptruser:pptruser /node_modules
+
+# Run everything after as non-privileged user.
+USER pptruser
+
+ENTRYPOINT ["dumb-init", "--"]
+# CMD ["google-chrome-unstable"]
+
+FROM puppeteer as puppeteerjest
+WORKDIR /home/pptruser
+COPY package.json .
+RUN npm install
+
+FROM puppeteerjest
+WORKDIR /home/pptruser
+COPY . .
+CMD ["npm", "test"]

--- a/puppeteer-and-jest-google/README.md
+++ b/puppeteer-and-jest-google/README.md
@@ -1,0 +1,31 @@
+# Chrome, Puppeteer and Jest Docker image
+
+Docker image that contains Google Chrome, puppeteer library and jest testing framework.
+
+The setting up of the Chrome and puppeteer is copied from puppeteer official website.
+
+The folder contains 5 files and 1 folder:
+* `README.md` this file.
+* `package.json` contains the information for jest installation.
+* `index.test.js` is test file.
+* `.dockerignore` contains files and directories that are not uploaded to the image.
+* `Dockerfile` contains the setting up of the docker image for chrome and puppeteer, loading package.json and copy test files.
+* Folder `screenshots` is used to save files that are copied from docker image.
+
+## How to build a docker image
+
+Build the image by executing the command:
+
+```
+docker build -t yousafazabi/puppeteer-goo .
+```
+
+## How to run the docker image
+
+Execute the command below to create a container that runs the tests.
+
+```
+docker run -v "`pwd`/screenshots:/home/pptruser/screenshots" yousafazabi/puppeteer-goo
+```
+
+The command mounts the localhost folder "*currentDirectory*/screenshots" to the container working directory "/home/pptruser/screenshots"

--- a/puppeteer-and-jest-google/index.test.js
+++ b/puppeteer-and-jest-google/index.test.js
@@ -1,0 +1,20 @@
+const puppeteer = require('puppeteer');
+const sources = require('puppeteer/DeviceDescriptors');
+const iPhone = sources['iPhone X'];
+
+describe('Test', () => {
+  it('should display "google" text on page', async () => {
+    const browser = await puppeteer.launch({
+        args: [
+            '--no-sandbox',
+            '--disable-setuid-sandbox'
+        ]
+    });
+    const page = await browser.newPage();
+    //await page.emulate(iPhone);
+    await page.goto('http://www.google.com', {waitUntil: 'networkidle2'});
+    await page.screenshot({path: 'screenshots/geovation.png'});
+    await expect(page.url()).toMatch('https://www.google.com/?gws_rd=ssl');
+    await browser.close();
+  });
+});

--- a/puppeteer-and-jest-google/package.json
+++ b/puppeteer-and-jest-google/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "docker_web_app_tester",
+  "version": "1.0.0",
+  "description": "Jest and Puppeteer on Docker",
+  "author": "Yousaf Azabi <yousaf.azabi.1@city.ac.uk>",
+  "main": "index.test.js",
+  "scripts": {
+    "start": "npm test",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^23.6.0"
+  }
+}


### PR DESCRIPTION
The steps to generate docker image for Chrome and puppeteer are taken from puppeteer official webpage.